### PR TITLE
Add and standardize getter methods, and optimize.

### DIFF
--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -27,7 +27,7 @@ pub struct EccCtx {
     fctx: FieldCtx,
     a: FieldElem,
     b: FieldElem,
-    pub n: BigUint,
+    n: BigUint,
     inv2: FieldElem,
 }
 
@@ -99,14 +99,19 @@ impl EccCtx {
         }
     }
 
-    pub fn get_a(&self) -> Vec<u8> {
-        self.a.to_bytes()
+    #[inline]
+    pub fn get_a(&self) -> &FieldElem {
+        &self.a
     }
-    pub fn get_b(&self) -> Vec<u8> {
-        self.b.to_bytes()
+
+    #[inline]
+    pub fn get_b(&self) -> &FieldElem {
+        &self.b
     }
-    pub fn get_n(&self) -> BigUint {
-        self.n.clone()
+
+    #[inline]
+    pub fn get_n(&self) -> &BigUint {
+        &self.n
     }
 
     pub fn inv_n(&self, x: &BigUint) -> BigUint {

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -115,51 +115,51 @@ impl EccCtx {
     }
 
     pub fn inv_n(&self, x: &BigUint) -> BigUint {
-        if x.clone() == BigUint::zero() {
+        if *x == BigUint::zero() {
             panic!("zero has no inversion.");
         }
 
         let mut u = x.clone();
-        let mut v = self.n.clone();
+        let mut v = self.get_n().clone();
         let mut a = BigUint::one();
         let mut c = BigUint::zero();
 
-        let n = self.n.clone();
+        let n = self.get_n().clone();
 
         let two = BigUint::from_u32(2).unwrap();
 
         while u != BigUint::zero() {
             if u.is_even() {
-                u = u / two.clone();
+                u = u / &two;
                 if a.is_even() {
-                    a = a / two.clone();
+                    a = a / &two;
                 } else {
-                    a = (a + n.clone()) / two.clone();
+                    a = (a + &n) / &two;
                 }
             }
 
             if v.is_even() {
-                v = v / two.clone();
+                v = v / &two;
                 if c.is_even() {
-                    c = c / two.clone();
+                    c = c / &two;
                 } else {
-                    c = (c + n.clone()) / two.clone();
+                    c = (c + &n) / &two;
                 }
             }
 
             if u >= v {
-                u = u - v.clone();
+                u = u - &v;
                 if a >= c {
-                    a = a - c.clone();
+                    a = a - &c;
                 } else {
-                    a = a + n.clone() - c.clone();
+                    a = a + &n - &c;
                 }
             } else {
-                v = v - u.clone();
+                v = v - &u;
                 if c >= a {
-                    c = c - a.clone();
+                    c = c - &a;
                 } else {
-                    c = c + n.clone() - a.clone();
+                    c = c + &n - &a;
                 }
             }
         }
@@ -442,7 +442,7 @@ impl EccCtx {
         loop {
             rng.fill_bytes(&mut buf[..]);
             ret = BigUint::from_bytes_be(&buf[..]);
-            if ret < self.n.clone() - BigUint::one() && ret != BigUint::zero() {
+            if ret < self.get_n() - BigUint::one() && ret != BigUint::zero() {
                 break;
             }
         }
@@ -575,7 +575,7 @@ mod tests {
 
         assert!(curve.eq(&double_g, &twice_g));
 
-        let n = curve.n.clone() - BigUint::one();
+        let n = curve.get_n() - BigUint::one();
         let new_g = curve.mul(&n, &g);
         let new_g = curve.add(&new_g, &double_g);
         assert!(curve.eq(&g, &new_g));
@@ -591,7 +591,7 @@ mod tests {
 
         assert!(curve.eq(&double_g, &twice_g));
 
-        let n = curve.n.clone() - BigUint::one();
+        let n = curve.get_n() - BigUint::one();
         let new_g = curve.g_mul(&n);
         let nn_g = curve.mul(&n, &g);
         assert!(curve.eq(&nn_g, &new_g));

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -169,15 +169,15 @@ impl SigCtx {
             let x_1 = x_1.to_biguint();
 
             // r = e + x_1
-            let r = (e.clone() + x_1) % curve.get_n();
-            if r == BigUint::zero() || r.clone() + k.clone() == *curve.get_n() {
+            let r = (&e + x_1) % curve.get_n();
+            if r == BigUint::zero() || &r + &k == *curve.get_n() {
                 continue;
             }
 
             // s = (1 + sk)^-1 * (k - r * sk)
-            let s1 = curve.inv_n(&(sk.clone() + BigUint::one()));
+            let s1 = curve.inv_n(&(sk + BigUint::one()));
 
-            let mut s2_1 = r.clone() * sk.clone();
+            let mut s2_1 = &r * sk;
             if s2_1 < k {
                 s2_1 = s2_1 + curve.get_n();
             }
@@ -210,27 +210,27 @@ impl SigCtx {
 
         let curve = &self.curve;
         // check r and s
-        if sig.r == BigUint::zero() || sig.s == BigUint::zero() {
+        if *sig.get_r() == BigUint::zero() || *sig.get_s() == BigUint::zero() {
             return false;
         }
-        if sig.r >= *curve.get_n() || sig.s >= *curve.get_n() {
+        if *sig.get_r() >= *curve.get_n() || *sig.get_s() >= *curve.get_n() {
             return false;
         }
 
         // calculate R
-        let t = (sig.s.clone() + sig.r.clone()) % curve.get_n();
+        let t = (sig.get_s() + sig.get_r()) % curve.get_n();
         if t == BigUint::zero() {
             return false;
         }
 
-        let p_1 = curve.add(&curve.g_mul(&sig.s), &curve.mul(&t, pk));
+        let p_1 = curve.add(&curve.g_mul(sig.get_s()), &curve.mul(&t, pk));
         let (x_1, _) = curve.to_affine(&p_1);
         let x_1 = x_1.to_biguint();
 
         let r_ = (e + x_1) % curve.get_n();
 
         // check R == r?
-        if r_ == sig.r {
+        if r_ == *sig.get_r() {
             return true;
         }
 

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -25,8 +25,7 @@ use yasna;
 
 use byteorder::{BigEndian, WriteBytesExt};
 
-pub type Pubkey = super::ecc::Point;
-type Point = super::ecc::Point;
+pub type Pubkey = Point;
 pub type Seckey = BigUint;
 
 pub struct Signature {


### PR DESCRIPTION
+ Add and standardize getter methods.
  + Add getter for Signature.
  + Getter return a reference of member, without cast and clone / copy.
+ Remove unnecessary clone().
  Tiny performance improvement.
+ Remove unnecessary type.