### PR TITLE
Fix Sm2Error debug impl

### DIFF
--- a/src/sm2/error.rs
+++ b/src/sm2/error.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
 use std::fmt::Formatter;
 
 pub enum Sm2Error {
@@ -24,7 +25,7 @@ pub enum Sm2Error {
 
 impl ::std::fmt::Debug for Sm2Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{}", self)
     }
 }
 
@@ -37,5 +38,30 @@ impl From<Sm2Error> for &str {
             Sm2Error::InvalidPublic => "invalid public key",
             Sm2Error::InvalidPrivate => "invalid private key",
         }
+    }
+}
+
+impl Display for Sm2Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let err_msg = match self {
+            Sm2Error::NotOnCurve => "the point not on curve",
+            Sm2Error::FieldSqrtError => "field elem sqrt error",
+            Sm2Error::InvalidDer => "invalid der",
+            Sm2Error::InvalidPublic => "invalid public key",
+            Sm2Error::InvalidPrivate => "invalid private key",
+        };
+        write!(f, "{}", err_msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Sm2Error;
+
+    #[test]
+    fn test_error_display() {
+        let e = Sm2Error::InvalidPublic;
+        assert_eq!(format!("{}", e), "invalid public key");
+        assert_eq!(format!("{:?}", e), "invalid public key");
     }
 }


### PR DESCRIPTION
```rust
#[cfg(test)]
mod tests {
    use super::Sm2Error;

    #[test]
    fn test_debug() {
        let e = Sm2Error::InvalidPublic;
        println!("{:?}", e); // thread 'sm2::error::tests::test_debug' has overflowed its stack
    }
}
```

This is because `{:?}`  will call the `Debug` impl itself.
```rust
impl ::std::fmt::Debug for Sm2Error {
    fn fmt(&self, f: &mut Formatter<'_>) -> ::std::fmt::Result {
        write!(f, "{:?}", self)
    }
}

```