### PR TITLE
use shr to replace div 2 for inv_n

### DIFF
--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -135,7 +135,7 @@ impl EccCtx {
 
         while ru != BigUint::zero() {
             if ru.is_even() {
-                ru = ru >> 1;
+                ru >>= 1;
                 if ra.is_even() {
                     ra = ra >> 1;
                 } else {

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -137,7 +137,7 @@ impl EccCtx {
             if ru.is_even() {
                 ru >>= 1;
                 if ra.is_even() {
-                    ra = ra >> 1;
+                    ra >>= 1;
                 } else {
                     ra = (ra + &rn) >> 1;
                 }

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -144,7 +144,7 @@ impl EccCtx {
             }
 
             if rv.is_even() {
-                rv = rv >> 1;
+                rv >>= 1;
                 if rc.is_even() {
                     rc >>= 1;
                 } else {

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -133,24 +133,22 @@ impl EccCtx {
 
         let rn = self.get_n().clone();
 
-        let two = BigUint::from_u32(2).unwrap();
-
         while ru != BigUint::zero() {
             if ru.is_even() {
-                ru /= &two;
+                ru = ru >> 1;
                 if ra.is_even() {
-                    ra /= &two;
+                    ra = ra >> 1;
                 } else {
-                    ra = (ra + &rn) / &two;
+                    ra = (ra + &rn) >> 1;
                 }
             }
 
             if rv.is_even() {
-                rv /= &two;
+                rv = rv >> 1;
                 if rc.is_even() {
-                    rc /= &two;
+                    rc = rc >> 1;
                 } else {
-                    rc = (rc + &rn) / &two;
+                    rc = (rc + &rn) >> 1;
                 }
             }
 

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -146,7 +146,7 @@ impl EccCtx {
             if rv.is_even() {
                 rv = rv >> 1;
                 if rc.is_even() {
-                    rc = rc >> 1;
+                    rc >>= 1;
                 } else {
                     rc = (rc + &rn) >> 1;
                 }


### PR DESCRIPTION
For the BigUint , the shift  right  operation (>>) takes only 25% of the time of the division operation, and replacing the right shift operation with the division operation can effectively improve the speed of calculating the multiplication inverse.
![BigUInt](https://user-images.githubusercontent.com/46491041/129821827-99f455c9-62e3-439a-b1ab-50c040f6b6ef.png)
