### PR TITLE
use w_naf to reduce time consume of point_mul

### DIFF
--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -135,7 +135,7 @@ impl EccCtx {
 
         while ru != BigUint::zero() {
             if ru.is_even() {
-                ru = ru >> 1;
+                ru >>= 1;
                 if ra.is_even() {
                     ra = ra >> 1;
                 } else {

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -137,7 +137,7 @@ impl EccCtx {
             if ru.is_even() {
                 ru >>= 1;
                 if ra.is_even() {
-                    ra = ra >> 1;
+                    ra >>= 1;
                 } else {
                     ra = (ra + &rn) >> 1;
                 }

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -144,7 +144,7 @@ impl EccCtx {
             }
 
             if rv.is_even() {
-                rv = rv >> 1;
+                rv >>= 1;
                 if rc.is_even() {
                     rc >>= 1;
                 } else {

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -390,9 +390,7 @@ impl EccCtx {
         let mut ret: [i8;257] = [0;257];
         let mut n:[u32;9] = [0;9];
 
-        for i in 1..9{
-            n[i] = m[i-1].clone();
-        }
+        n[1..9].clone_from_slice(&m[..8]);
 
         let window: u32 = (1 << w) -1;
 
@@ -418,7 +416,7 @@ impl EccCtx {
             carry = (word >> (w-1)) & 1;
             ret[bit] = word as i8 - (carry<<w) as i8;
 
-            *lst = 0+bit;
+            *lst = bit;
             bit += w;
 
         }

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -743,7 +743,7 @@ mod tests {
             }
             init = init >> 1;
         }
-        assert_eq!(sum,n);
+        assert_eq!(sum, n);
     }
 
     #[test]

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -387,8 +387,8 @@ impl EccCtx {
     pub fn w_naf(&self, m:&[u32], w: usize, lst: &mut usize) -> [i8;257]{
         let mut carry = 0;
         let mut bit = 0;
-        let mut ret: [i8;257] = [0;257];
-        let mut n:[u32;9] = [0;9];
+        let mut ret: [i8; 257] = [0; 257];
+        let mut n:[u32; 9] = [0; 9];
 
         n[1..9].clone_from_slice(&m[..8]);
 

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -440,7 +440,7 @@ impl EccCtx {
         table[1 + offset] = p.clone();
         table[offset - 1] = self.neg(&table[1 + offset]);
         for i in 1..8 {
-            table[2 * i + offset + 1] = self.add(&double_p,&table[2 * i + offset -1]);
+            table[2 * i + offset + 1] = self.add(&double_p, &table[2 * i + offset -1]);
             table[offset - 2 * i - 1] = self.neg(&table[2 * i + offset + 1]);
         }
 

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -133,24 +133,22 @@ impl EccCtx {
 
         let rn = self.get_n().clone();
 
-        let two = BigUint::from_u32(2).unwrap();
-
         while ru != BigUint::zero() {
             if ru.is_even() {
-                ru /= &two;
+                ru = ru >> 1;
                 if ra.is_even() {
-                    ra /= &two;
+                    ra = ra >> 1;
                 } else {
-                    ra = (ra + &rn) / &two;
+                    ra = (ra + &rn) >> 1;
                 }
             }
 
             if rv.is_even() {
-                rv /= &two;
+                rv = rv >> 1;
                 if rc.is_even() {
-                    rc /= &two;
+                    rc = rc >> 1;
                 } else {
-                    rc = (rc + &rn) / &two;
+                    rc = (rc + &rn) >> 1;
                 }
             }
 

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -720,7 +720,7 @@ mod tests {
         let mut lst = 0;
 
         let n = curve.get_n() - BigUint::one();
-        let _num = BigUint::from(1122334455 as u32)-BigUint::one();
+        let _num = BigUint::from(1122334455 as u32) - BigUint::one();
 
         let k = FieldElem::from_biguint(&n);
         let ret = curve.w_naf(&k.value,5,&mut lst);

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -434,7 +434,7 @@ impl EccCtx {
         let mut q = self.zero();
         let naf = self.w_naf(&m,5, &mut i);
         let offset = 16;
-        let mut table = [self.zero();32];
+        let mut table = [self.zero(); 32];
         let double_p = self.double(&p);
 
         table[1+offset] = p.clone();

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -437,9 +437,9 @@ impl EccCtx {
         let mut table = [self.zero(); 32];
         let double_p = self.double(&p);
 
-        table[1+offset] = p.clone();
-        table[offset-1] = self.neg(&table[1+offset]);
-        for i in 1..8{
+        table[1 + offset] = p.clone();
+        table[offset - 1] = self.neg(&table[1 + offset]);
+        for i in 1..8 {
             table[2 * i + offset + 1] = self.add(&double_p,&table[2 * i + offset -1]);
             table[offset - 2 * i - 1] = self.neg(&table[2 * i + offset + 1]);
         }

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -723,7 +723,7 @@ mod tests {
         let _num = BigUint::from(1122334455 as u32) - BigUint::one();
 
         let k = FieldElem::from_biguint(&n);
-        let ret = curve.w_naf(&k.value,5,&mut lst);
+        let ret = curve.w_naf(&k.value,5, &mut lst);
         let mut sum = BigUint::zero();
         let mut init = BigUint::from_str_radix(
             "10000000000000000000000000000000000000000000000000000000000000000",

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -146,7 +146,7 @@ impl EccCtx {
             if rv.is_even() {
                 rv = rv >> 1;
                 if rc.is_even() {
-                    rc = rc >> 1;
+                    rc >>= 1;
                 } else {
                     rc = (rc + &rn) >> 1;
                 }

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -384,7 +384,7 @@ impl EccCtx {
         self.mul_raw_naf(&k.value, p)
     }
 
-    pub fn w_naf(&self, m:&[u32], w: usize, lst: &mut usize) -> [i8;257]{
+    pub fn w_naf(&self, m: &[u32], w: usize, lst: &mut usize) -> [i8; 257]{
         let mut carry = 0;
         let mut bit = 0;
         let mut ret: [i8; 257] = [0; 257];

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -732,7 +732,7 @@ mod tests {
 
         for j in 0..257{
             let i = 256 - j;
-            if ret[i]!=0{
+            if ret[i] != 0{
                 if ret[i] > 0{
                     sum += &init * BigUint::from(ret[i] as u8);
                 }

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -27,7 +27,7 @@ pub struct EccCtx {
     n: BigUint,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Copy)]
 pub struct Point {
     pub x: FieldElem,
     pub y: FieldElem,
@@ -381,7 +381,85 @@ impl EccCtx {
 
         let k = FieldElem::from_biguint(&m);
 
-        self.mul_raw(&k.value, p)
+        self.mul_raw_naf(&k.value, p)
+    }
+
+    pub fn w_naf(&self, m:&[u32], w: usize, lst: &mut usize) -> [i8;257]{
+        let mut carry = 0;
+        let mut bit = 0;
+        let mut ret: [i8;257] = [0;257];
+        let mut n:[u32;9] = [0;9];
+
+        for i in 1..9{
+            n[i] = m[i-1].clone();
+        }
+
+        let window: u32 = (1 << w) -1;
+
+        while bit < 256 {
+            let u32_idx = 8 - bit as usize / 32;
+            let bit_idx = 31 - bit as usize % 32;
+            let mut word: u32 ;
+
+            if ((n[u32_idx] >> (31 - bit_idx)) & 1) == carry{
+                bit += 1;
+                continue;
+            }
+
+            if bit_idx >= w-1 {
+                word = (n[u32_idx] >> (31 - bit_idx)) & window;
+            }
+            else{
+                word = ((n[u32_idx] >> (31 - bit_idx)) | (n[u32_idx - 1] << (bit_idx + 1)) ) & window;
+            }
+
+            word += carry;
+
+            carry = (word >> (w-1)) & 1;
+            ret[bit] = word as i8 - (carry<<w) as i8;
+
+            *lst = 0+bit;
+            bit += w;
+
+        }
+
+        if carry == 1{
+            ret[256] = 1;
+            *lst = 256;
+        }
+
+        ret
+    }
+
+    pub fn mul_raw_naf(&self, m: &[u32], p: &Point) -> Point {
+        let mut i = 256;
+        let mut q = self.zero();
+        let naf = self.w_naf(&m,5, &mut i);
+        let offset = 16;
+        let mut table = [self.zero();32];
+        let double_p = self.double(&p);
+
+        table[1+offset] = p.clone();
+        table[offset-1] = self.neg(&table[1+offset]);
+        for i in 1..8{
+            table[2 * i + offset + 1] = self.add(&double_p,&table[2 * i + offset -1]);
+            table[offset - 2 * i - 1] = self.neg(&table[2 * i + offset + 1]);
+        }
+
+        loop {
+            q = self.double(&q);
+
+            if naf[i] != 0 {
+                let index = (naf[i] + 16) as usize;
+                q = self.add(&q, &table[index]);
+            }
+
+            if i == 0 {
+                break;
+            }
+            i -= 1;
+        }
+        q
     }
 
     pub fn mul_raw(&self, m: &[u32], p: &Point) -> Point {
@@ -636,6 +714,38 @@ mod tests {
         let new_g = curve.g_mul(&n);
         let nn_g = curve.mul(&n, &g);
         assert!(curve.eq(&nn_g, &new_g));
+    }
+
+    #[test]
+    fn test_w_naf() {
+        let curve = EccCtx::new();
+        let mut lst = 0;
+
+        let n = curve.get_n() - BigUint::one();
+        let _num = BigUint::from(1122334455 as u32)-BigUint::one();
+
+        let k = FieldElem::from_biguint(&n);
+        let ret = curve.w_naf(&k.value,5,&mut lst);
+        let mut sum = BigUint::zero();
+        let mut init = BigUint::from_str_radix(
+            "10000000000000000000000000000000000000000000000000000000000000000",
+            16,
+        ).unwrap();
+
+        for j in 0..257{
+            let i = 256 - j;
+            if ret[i]!=0{
+                if ret[i] > 0{
+                    sum += &init * BigUint::from(ret[i] as u8);
+                }
+                else{
+                    let neg = (0 - ret[i]) as u8;
+                    sum -= &init * BigUint::from(neg as u8);
+                }
+            }
+            init = init >> 1;
+        }
+        assert_eq!(sum,n);
     }
 
     #[test]

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -413,8 +413,8 @@ impl EccCtx {
 
             word += carry;
 
-            carry = (word >> (w-1)) & 1;
-            ret[bit] = word as i8 - (carry<<w) as i8;
+            carry = (word >> (w - 1)) & 1;
+            ret[bit] = word as i8 - (carry << w) as i8;
 
             *lst = bit;
             bit += w;


### PR DESCRIPTION
w-naf can effectively reduce the time consumption of point multiplication. In sm2, we set the width of the window to 5, and the except time consumption is 50A+257D where the origin time consumption is 128A+256D.


