### PR TITLE
replace mul with gmul in pk_from_sk function

### DIFF
--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -313,7 +313,7 @@ impl SigCtx {
         if *sk >= *curve.get_n() || *sk == BigUint::zero() {
             return Err(Sm2Error::InvalidSecretKey);
         }
-        curve.mul(sk, &curve.generator()?)
+        curve.g_mul(sk)
     }
 
     pub fn load_pubkey(&self, buf: &[u8]) -> Result<Point, Sm2Error> {


### PR DESCRIPTION
It's not necessary to use expensive mul operations in pk_from_sk functions, replacing it with g_mul can reduce execution time